### PR TITLE
build(fastp): multi-stage Dockerfile

### DIFF
--- a/dockerfiles/multiarch/fastp/Dockerfile
+++ b/dockerfiles/multiarch/fastp/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS builder
 
 ARG LIBISAL_VERSION=v2.31.1
 ARG LIBDEFLATE_VERSION=v1.25
@@ -49,3 +49,21 @@ RUN git clone --branch "${FASTP_VERSION}" --depth 1 https://github.com/OpenGene/
     make install && \
     cd .. && \
     rm -rf fastp
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/lib
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libhwy1t64 \
+        zlib1g && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/fastp /usr/local/bin/fastp
+COPY --from=builder /usr/local/lib/libdeflate.so* /usr/local/lib/
+COPY --from=builder /usr/lib/libisal.so* /usr/lib/
+COPY LICENSE.txt /licenses/fastp/LICENSE.txt


### PR DESCRIPTION
## Summary
- Convert `dockerfiles/multiarch/fastp/Dockerfile` to multi-stage build (builder + runtime)
- Runtime image carries only the fastp binary and required shared libraries (libisal, libdeflate)
- Sets `LD_LIBRARY_PATH` for runtime library resolution

## Issues
Closes #9 (final slice 3/3)

## Test plan
- [ ] `docker buildx build dockerfiles/multiarch/fastp` succeeds
- [ ] `fastp --version` works in runtime image
- [ ] `scripts/verify_built_images.sh fastp` passes