### PR TITLE
feat: add Singularity/Apptainer + Conda execution profiles (portability)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           version: '23.04.0'
 
       - name: Verify pipeline parses and --help works
-        run: nextflow run main.nf --help -ansi-log false
+        run: nextflow run main.nf --help -profile docker -ansi-log false
 
       - name: Verify manifest validation failures are readable
         run: |
@@ -96,6 +96,7 @@ jobs:
             --input_file test_data/phage_smoke.csv \
             --cpus 1 \
             --email test@example.com \
+            -profile docker \
             -stub-run \
             -ansi-log false
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 ci: pipeline-check manifest-validation manifest-stub image-manifest-tests build-images-tests
 
 pipeline-check:
-	nextflow run main.nf --help -ansi-log false
+	nextflow run main.nf --help -profile docker -ansi-log false
 
 manifest-validation:
 	@bad_json="$$(mktemp)" && \
@@ -60,7 +60,7 @@ manifest-validation:
 	rm -f "$$ignored_extra_manifest"
 
 manifest-stub: clean-ci-artifacts
-	nextflow run main.nf --input_file test_data/phage_smoke.csv --cpus 1 --email test@example.com -stub-run -ansi-log false
+	nextflow run main.nf --input_file test_data/phage_smoke.csv --cpus 1 --email test@example.com -profile docker -stub-run -ansi-log false
 	grep -R --fixed-strings --quiet "docker.io/eoksen/fastp:1.3.0" work/*/*/.command.run
 
 image-manifest-tests:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ SRA Alignment Pipeline
 - You can learn more about these databases by following these links: [SRA](https://www.ncbi.nlm.nih.gov/sra/docs/) and [NCBI Nucleotide](https://www.ncbi.nlm.nih.gov/books/NBK49541/). 
 
 ## Installation
-**Important:** Before you can use this pipeline, you need to install Nextflow and Docker. 
+**Important:** Before you can use this pipeline, you need to install Nextflow and a supported container engine.
 - Nextflow can be installed by following the instructions [here](https://www.nextflow.io/docs/latest/getstarted.html). 
 - Docker can be installed by following the instructions [here](https://docs.docker.com/get-docker/). 
+- The pipeline selects its container/environment engine with `-profile` (Docker, Singularity, Apptainer, Podman, or experimental Conda). On HPC/cluster environments where the Docker daemon is not permitted, use `-profile singularity` or `-profile apptainer` (both pull the existing Docker images directly). See [Execution Profiles](#execution-profiles) for details.
 - This pipeline now resolves its runtime images from a tracked image manifest and has been modernized for current multi-architecture Docker builds. Local validation in this repository was performed with Nextflow 22.10.7 and Docker 29.x on arm64, and CI currently exercises Nextflow 23.04.0 on Ubuntu.
 
 ## Input Data
@@ -74,10 +75,27 @@ The pipeline uses several different open-source packages, including:
 | `run_qualimap` | **Qualimap** | The `run_qualimap` process uses qualimap to produce a quality control report for the sorted BAM file produced by samtools. | [Qualimap](http://qualimap.conesalab.org/) | [Qualimap](http://qualimap.conesalab.org/doc_html/index.html) | qualimap:2.3 |
 
 ## Usage
+
+### Execution Profiles
+
+Processes run inside containers, and you must select a container/environment engine explicitly with `-profile <engine>`. Profiles are **mutually exclusive** — exactly one engine is enabled per run, and no engine is enabled by default. Docker is the documented default engine, so existing commands simply add `-profile docker`.
+
+| Profile | Engine | Notes |
+| --- | --- | --- |
+| `docker` | Docker | Default documented engine. |
+| `singularity` | Singularity | For HPC/clusters where Docker is not permitted. `autoMounts` enabled. Pulls the existing Docker images directly. |
+| `apptainer` | Apptainer | Apptainer (the successor to Singularity). `autoMounts` enabled. Pulls the existing Docker images directly. |
+| `conda` | Conda | **Experimental** — scaffold only, pending the biocontainers migration ([issue #32](https://github.com/eoksen/sra_alignment_pipeline/issues/32)). Current runtime images are custom Docker images that do not translate to Conda, so this profile is not yet usable. |
+| `podman` | Podman | Optional Docker-compatible daemonless engine. |
+
+Add the profile flag to any `nextflow run` command, e.g. `-profile docker` or `-profile singularity`.
+
 ```
-nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main [OPTIONS] OR nextflow run main.nf [OPTIONS]
+nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main -profile docker [OPTIONS] OR nextflow run main.nf -profile docker [OPTIONS]
 
 OPTIONS:
+-profile <docker|singularity|apptainer|conda|podman> Container/environment engine used to run processes. Required. Docker is the documented default; singularity/apptainer suit HPC clusters; conda is experimental (see Execution Profiles above).
+
 --cpus <int> The number of CPUs you want to use for processing, default: 2. Only the cpus available to your docker daemon can be used.
 
 --email <ncbi-email-address> Your email address registered with NCBI, required.
@@ -109,10 +127,10 @@ OPTIONS:
 ### **Option #1: Run from Github**
 To run with sra_accession and identifier provided on the cli, execute the following command in your terminal
 ```bash
-nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main --sra_accession <sra_accession> --identifier <ncbi-id> --cpus <int> --email <ncbi-email-address> -resume```
+nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main -profile docker --sra_accession <sra_accession> --identifier <ncbi-id> --cpus <int> --email <ncbi-email-address> -resume```
 To run with an input file, execute the following command in your terminal
 ```bash
-nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main --input_file <path/to/input/file.csv> --cpus <int> --email <ncbi-email-address> -resume```
+nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main -profile docker --input_file <path/to/input/file.csv> --cpus <int> --email <ncbi-email-address> -resume```
 
 ### **Option #2: Clone repo from Github to your local environment**
 You can clone the repo using either by HTTPS:
@@ -126,16 +144,16 @@ gh repo clone eoksen/sra_alignment_pipeline
 To run with sra_accession and identifier provided on the cli, execute the following command in your terminal at the root of the cloned repo:
 
 ```bash
-nextflow run main.nf --sra_accession <sra_accession> --identifier <ncbi-id> --cpus <int> --email <ncbi-email-address> -resume
+nextflow run main.nf -profile docker --sra_accession <sra_accession> --identifier <ncbi-id> --cpus <int> --email <ncbi-email-address> -resume
 ```
 To run with an input file, execute the following command in your terminal at the root of the cloned repo:
 ```bash
-nextflow run main.nf --input_file <path/to/input/file.csv> --cpus <int> --email <ncbi-email-address> -resume```
+nextflow run main.nf -profile docker --input_file <path/to/input/file.csv> --cpus <int> --email <ncbi-email-address> -resume```
 
 ## Test the Pipeline
 Two input files are provided in the `test_data` directory. To run the pipeline on the test data, execute the following command in your terminal at the root of the cloned repo:
 ```bash
-nextflow run main.nf --input_file test_data/test1/test1.csv --cpus <int> --email <ncbi-email-address> -resume```
+nextflow run main.nf -profile docker --input_file test_data/test1/test1.csv --cpus <int> --email <ncbi-email-address> -resume```
 
 For this file, process execution should look like:
 
@@ -168,7 +186,7 @@ scripts/archive_nf.sh
 
 Or you can run the pipeline and the script in one command:
 ```bash
-nextflow run main.nf --input_file test_data/test1/test1.csv --cpus <int> --email <ncbi-email-address> -resume && scripts/archive_nf.sh
+nextflow run main.nf -profile docker --input_file test_data/test1/test1.csv --cpus <int> --email <ncbi-email-address> -resume && scripts/archive_nf.sh
 ```
 This command will:
 
@@ -185,7 +203,7 @@ Remember to run the script from the same directory where you ran the Nextflow pi
 ## Pipeline Directed Acyclic Graphs
 - DAGs were generated using the `-with-dag` option with both `nextflow run` command, e.g.:
 ```bash
-nextflow run main.nf --input_file <path/to/input/file.csv> --cpus <int> --email <ncbi-email-address> -resume -with-dag dag_name.mmd
+nextflow run main.nf -profile docker --input_file <path/to/input/file.csv> --cpus <int> --email <ncbi-email-address> -resume -with-dag dag_name.mmd
 ```
 - The contents of the .mmd file were then loaded into [Mermaidv10.2.2 Live Editor](https://mermaid.live/edit#pako:eNpVjk2Lg0AMhv9KyGkL9Q94WGh1t5fCFurN6SFo7AztfDBGpKj_fcd62c0pvM_zhkzY-JYxx-7px0ZTFKhK5SDNoS50NL1Y6m-QZZ_ziQWsd_ya4fhx8tBrH4Jx993mH1cJium8agyijXssGyre_R_HM5T1mYL4cPtLqtHP8FWbi07n_xMdObW-647yjrKGIhQU3wru0XK0ZNr0_rQmCkWzZYV5WlvuaHiKQuWWpNIg_vpyDeYSB97jEFoSLg3dI9ktXH4B_cJWqw) to create the DAGs below.
 

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -1,3 +1,0 @@
-docker {
-    enabled = true
-}

--- a/main.nf
+++ b/main.nf
@@ -115,8 +115,15 @@ if (params.help) {
     ======================
 
     Usage:
-      nextflow run main.nf [OPTIONS]
-      nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main [OPTIONS]
+      nextflow run main.nf -profile docker [OPTIONS]
+      nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main -profile docker [OPTIONS]
+
+    Execution profile (required to run processes; choose ONE engine):
+      -profile docker           Run processes with Docker (default documented engine)
+      -profile singularity      Run processes with Singularity (HPC; autoMounts enabled)
+      -profile apptainer        Run processes with Apptainer (HPC; autoMounts enabled)
+      -profile conda            EXPERIMENTAL, pending biocontainers migration (issue #32)
+      -profile podman           Run processes with Podman
 
     Required:
       --email <address>         NCBI-registered email address

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,9 +1,36 @@
 nextflow.enable.dsl=2
 
 includeConfig 'conf/params.config'
-includeConfig 'conf/docker.config'
 
 process.scratch = true
+
+// Execution profiles select the container/environment engine used to run
+// processes. They are MUTUALLY EXCLUSIVE: no engine is enabled globally, so a
+// profile MUST be selected explicitly (e.g. `-profile docker`). Docker remains
+// the documented default engine. See README.md and `main.nf --help`.
+profiles {
+    docker {
+        docker.enabled = true
+    }
+    singularity {
+        singularity.enabled = true
+        singularity.autoMounts = true
+    }
+    apptainer {
+        apptainer.enabled = true
+        apptainer.autoMounts = true
+    }
+    conda {
+        // EXPERIMENTAL — scaffold only, pending the biocontainers migration (issue #32).
+        // Current runtime images are custom Docker images (docker.io/eoksen/*) that do
+        // NOT translate to Conda automatically, so this profile does not yet provide a
+        // working environment. Singularity/Apptainer can pull the Docker images directly.
+        conda.enabled = true
+    }
+    podman {
+        podman.enabled = true
+    }
+}
 
 report {
     enabled = true


### PR DESCRIPTION
## Summary

Converts the single hard-coded Docker enablement into named, **mutually-exclusive** `-profile` execution profiles, so the pipeline can run under Singularity/Apptainer (HPC) and Podman in addition to Docker, with a Conda scaffold for the future biocontainers migration.

- `conf/docker.config` (which globally set `docker.enabled = true`) is **deleted** and its `includeConfig` line removed. Docker enablement now lives in the `docker` profile.
- New `profiles { }` block in `nextflow.config`: `docker`, `singularity` (+`autoMounts`), `apptainer` (+`autoMounts`), `conda` (experimental scaffold), `podman`.
- **No engine is enabled globally** — a profile must be selected explicitly. Docker remains the documented default engine.
- CI/Makefile process-executing runs now select `-profile docker`; README and `main.nf --help` document `-profile`.

Closes #26

## Commits (atomic, not squashed)

- `refactor(config): replace conf/docker.config with mutually-exclusive execution profiles`
- `ci: select -profile docker for process-executing nextflow runs`
- `docs: document -profile execution engines in README and --help`

## Conda profile — experimental

The `conda` profile is a scaffold (`conda.enabled = true`) marked EXPERIMENTAL in `nextflow.config`, `--help`, and the README. Current runtime images are custom Docker images (`docker.io/eoksen/*`) that do not translate to Conda automatically; full Conda support is coupled to the biocontainers migration (#32). Singularity/Apptainer, by contrast, pull the existing Docker images directly and are intended to work fully.

## Singularity real-run caveat (needs HPC/Singularity-enabled runner)

Singularity/Apptainer are **not installed on the dev machine**, so a real Singularity run was **NOT executed**. Per issue validation #4, portability is proven here via config resolution (see check 3 below), and the exact intended command is documented for a Singularity-enabled environment:

```bash
nextflow run main.nf \
  --input_file test_data/phage_smoke.csv \
  --cpus 1 \
  --email test@example.com \
  -profile singularity \
  -ansi-log false
```

(Once real `stub:` blocks land — #30 — add `-stub-run` for a fast hermetic check.) This must be run on an HPC/Singularity-enabled runner to fully validate the Singularity path end-to-end.

## Validation evidence (run locally, Nextflow 22.10.7)

### [1] `grep -n "profiles" nextflow.config`

```
7:// Execution profiles select the container/environment engine used to run
11:profiles {
```

Full block:

```groovy
profiles {
    docker {
        docker.enabled = true
    }
    singularity {
        singularity.enabled = true
        singularity.autoMounts = true
    }
    apptainer {
        apptainer.enabled = true
        apptainer.autoMounts = true
    }
    conda {
        // EXPERIMENTAL — scaffold only, pending the biocontainers migration (issue #32).
        // Current runtime images are custom Docker images (docker.io/eoksen/*) that do
        // NOT translate to Conda automatically, so this profile does not yet provide a
        // working environment. Singularity/Apptainer can pull the Docker images directly.
        conda.enabled = true
    }
    podman {
        podman.enabled = true
    }
}
```

### [2] `nextflow run main.nf --help -profile docker -ansi-log false`

```
exit code: 0
```

### [3a] `nextflow config main.nf -profile singularity`

```
singularity {
   enabled = true
   autoMounts = true
```
`docker.enabled` present under `-profile singularity`? **NO (GOOD)**

### [3b] `nextflow config main.nf -profile docker`

```
docker {
   enabled = true
}
```
`singularity.enabled` present under `-profile docker`? **NO (GOOD)** — profiles are mutually exclusive.

### [4] `nextflow config main.nf` (no profile) — no engine enabled globally

```
(no engine block present globally — GOOD)
```

Proves mutual exclusivity / no global default engine.

### [5] Fast local CI checks

```
make pipeline-check      exit: 0
make manifest-validation exit: 0
```

The manifest-VALIDATION assertions (malformed / non-object / missing-defaults / missing-required / ignored-extra) were left **unchanged** so their exact error strings still match. The slow `make manifest-stub` / full stub run (real network + image pull; hermetic `stub:` blocks pending #30) was **not** run locally — it is exercised by GitHub Actions on this branch under the new `-profile docker`.

### [6] `-profile` documented

- `main.nf --help` now has an "Execution profile" section listing `docker|singularity|apptainer|conda|podman`, noting docker is the default documented engine and conda is experimental.
- `README.md` gains an "Execution Profiles" section (engine table + guidance), documents `-profile` in the options list, notes alternative engines in Installation, and adds explicit `-profile docker` to every runnable example command.

## Out-of-scope follow-ups noticed

- Real Singularity/Apptainer end-to-end validation needs an HPC/Singularity-enabled CI runner (not available locally). Worth a follow-up if a Singularity CI lane is desired.
- The `conda` profile becomes genuinely usable only after the biocontainers migration (#32).

https://claude.ai/code/session_01ApqSavpo9PW6RN5ohRMmdj
