### PR TITLE
feat: add MultiQC aggregated reporting (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ The pipeline automatically generates Nextflow execution reports under the output
 
 These are generated on every run. Open the HTML files in a browser to review.
 
+### Aggregated QC Report (MultiQC)
+After the per-sample QC and stats steps run, the `run_multiqc` process aggregates their outputs into a single interactive report (paths shown for the default `--outdir results`):
+- `results/multiqc/multiqc_report.html` — one HTML report summarizing every sample and step, including a General Statistics table.
+- `results/multiqc/multiqc_data/` — the parsed data tables and source list backing the report.
+
+MultiQC collects and parses the fastp JSON, bowtie2 alignment summary, qualimap bamqc results, and bcftools stats produced earlier in the run. Like all published outputs, it is written under `--outdir` (default `results/`), so `--outdir <path>` relocates it to `<path>/multiqc/`.
+
 ## Pipeline Overview
 The pipeline uses several different open-source packages, including:
 
@@ -73,6 +80,7 @@ The pipeline uses several different open-source packages, including:
 | `run_samtools` | **Samtools** | The `run_samtools` uses samtools to convert the alignment file from `run_bowtie2` from SAM to BAM and then sorts the BAM file. Additionally, samtools indexes the BAM file and the reference genome. | [Samtools](http://www.htslib.org/doc/samtools.html) | [Samtools](https://github.com/samtools/samtools) | samtools:1.23.1 |
 | `run_bcftools`, `run_bcftools_filter` | **Bcftools** | Bcftools is used in two distinct ways in this pipeline. Initially, in the `run_bcftools` process, Bcftools is employed for calling variants, generating consensus sequences, and producing statistical data and plots associated with the variant calling. Subsequently, in the `run_bcftools_filter` process, Bcftools filters variants based on inclusion or exclusion criteria provided by the user, generating filtered VCF files, statistics, and plots. If neither --include or --exclude options are provided by the user, then the filtering step will be skipped. | [Bcftools](http://www.htslib.org/doc/bcftools.html) | [Bcftools](https://github.com/samtools/bcftools) | bcftools:1.23.1 |
 | `run_qualimap` | **Qualimap** | The `run_qualimap` process uses qualimap to produce a quality control report for the sorted BAM file produced by samtools. | [Qualimap](http://qualimap.conesalab.org/) | [Qualimap](http://qualimap.conesalab.org/doc_html/index.html) | qualimap:2.3 |
+| `run_multiqc` | **MultiQC** | The `run_multiqc` process aggregates the per-sample QC/stats artifacts (fastp JSON, bowtie2 alignment summary, qualimap bamqc, bcftools stats) into a single interactive `multiqc_report.html` plus a `multiqc_data/` directory under `${outdir}/multiqc/`. It runs from the pinned biocontainer `quay.io/biocontainers/multiqc:1.25--pyhdfd78af_0`. | [MultiQC](https://multiqc.info/) | [MultiQC](https://github.com/MultiQC/MultiQC) | multiqc:1.25 |
 
 ## Usage
 

--- a/main.nf
+++ b/main.nf
@@ -193,6 +193,8 @@ include { run_samtools } from './nf_scripts/run_samtools' addParams(container_im
 include { run_bcftools } from './nf_scripts/run_bcftools' addParams(container_image: resolvedContainerImages['bcftools'])
 include { run_qualimap } from './nf_scripts/run_qualimap' addParams(container_image: resolvedContainerImages['qualimap'])
 include { run_bcftools_filter } from './nf_scripts/run_bcftools_filter' addParams(container_image: resolvedContainerImages['bcftools'])
+// run_multiqc hardcodes its own biocontainer, so it needs no container_image param.
+include { run_multiqc } from './nf_scripts/run_multiqc'
 
 workflow {
     if ( params.sra_accession && params.identifier && params.input_file == '' ) {
@@ -263,4 +265,16 @@ workflow {
     if ( params.include || params.exclude ) {
         run_bcftools_filter( run_bcftools.out.vcf_files )
     }
+
+    // Aggregate every per-sample QC/stats artifact into one MultiQC report.
+    // Mix the QC-producing outputs and collect() them into a single channel so
+    // MultiQC runs once over all files (fastp JSON, bowtie2 align summary,
+    // qualimap dir, bcftools stats).
+    multiqc_files = run_fastp.out.fastp_json_report
+        .mix( run_bowtie2.out.align_summary )
+        .mix( run_qualimap.out.qualimap_results )
+        .mix( run_bcftools.out.stats_files )
+        .collect()
+
+    run_multiqc( multiqc_files )
 }

--- a/nf_scripts/run_bowtie2.nf
+++ b/nf_scripts/run_bowtie2.nf
@@ -8,15 +8,17 @@ process run_bowtie2 {
 
     output:
     tuple val(name), path("${name}.sam"), path("${name}_pair.align"), path("${name}_pair.unmapped"), emit: bowtie2_output
+    path("${name}_bowtie2_summary.log"), emit: align_summary
 
     script:
     """
     bowtie2-build -f ${downloaded_fasta} ref_index -p ${task.cpus}
-    bowtie2 -p ${task.cpus} -x ref_index -1 ${forward_reads} -2 ${reverse_reads} -S ${name}.sam --al ${name}_pair.align --un ${name}_pair.unmapped -L ${params.L} -X ${params.X} --fr -q -t
+    bowtie2 -p ${task.cpus} -x ref_index -1 ${forward_reads} -2 ${reverse_reads} -S ${name}.sam --al ${name}_pair.align --un ${name}_pair.unmapped -L ${params.L} -X ${params.X} --fr -q -t 2> ${name}_bowtie2_summary.log
     """
 
     stub:
     """
     touch ${name}.sam ${name}_pair.align ${name}_pair.unmapped
+    touch ${name}_bowtie2_summary.log
     """
 }

--- a/nf_scripts/run_multiqc.nf
+++ b/nf_scripts/run_multiqc.nf
@@ -1,0 +1,28 @@
+process run_multiqc {
+    label 'process_low'
+    // Pinned biocontainer (not a custom eoksen image) to keep this PR focused and
+    // off the manifest-validation logic; issue #32 can consolidate it into the
+    // manifest later. Tag confirmed pullable via `docker manifest inspect`.
+    container 'quay.io/biocontainers/multiqc:1.25--pyhdfd78af_0'
+
+    publishDir "${params.outdir}/multiqc", mode: 'copy'
+
+    input:
+    path(qc_files)
+
+    output:
+    path("multiqc_report.html"), emit: report
+    path("multiqc_data"), emit: data
+
+    script:
+    """
+    multiqc . --force
+    """
+
+    stub:
+    """
+    touch multiqc_report.html
+    mkdir -p multiqc_data
+    touch multiqc_data/multiqc_sources.txt
+    """
+}


### PR DESCRIPTION
## Summary
Adds MultiQC aggregated reporting (issue #29). After the per-sample QC/stats steps run, a new `run_multiqc` process aggregates their outputs into one interactive `multiqc_report.html` + `multiqc_data/` published under `${params.outdir}/multiqc/`.

Closes #29

## Changes (atomic commits)
1. `feat(multiqc): add run_multiqc process with pinned biocontainer` — new `nf_scripts/run_multiqc.nf`: `label 'process_low'`, `publishDir "${params.outdir}/multiqc"`, runs `multiqc . --force`, emits `report`/`data`, plus a `stub:` block. Container is hardcoded to the pinned biocontainer `quay.io/biocontainers/multiqc:1.25--pyhdfd78af_0` (not a custom eoksen image) to keep this PR off the manifest-validation logic; #32 can consolidate into the manifest later.
2. `feat(bowtie2): emit alignment summary log for MultiQC` — redirect the bowtie2 ALIGN command's STDERR to `${name}_bowtie2_summary.log` and emit it as a **separate** `align_summary` output. The existing 4-member `bowtie2_output` tuple (consumed by `run_samtools`) is untouched. Stub updated.
3. `feat(multiqc): wire collect + run_multiqc into main workflow` — `include { run_multiqc }` (no addParams needed) and mix the four QC channels (`run_fastp.out.fastp_json_report`, `run_bowtie2.out.align_summary`, `run_qualimap.out.qualimap_results`, `run_bcftools.out.stats_files`) then `.collect()` into a single channel fed to `run_multiqc`.
4. `docs(multiqc): document aggregated MultiQC report in README` — Output Data subsection + Pipeline Overview table row.

## Container evidence
`docker manifest inspect quay.io/biocontainers/multiqc:1.25--pyhdfd78af_0` succeeds (schemaVersion 2, single-arch linux/amd64 image; runs under emulation on arm64).

## Validation
- **Stub run** (`-stub-run`, `--cpus 1`, `-profile docker`): completes end-to-end; `run_multiqc` executes and produces `results/multiqc/multiqc_report.html` + `results/multiqc/multiqc_data/multiqc_sources.txt`. Confirmed the `collect()` staged all four QC inputs into the multiqc work dir (fastp JSON, qualimap dir, bowtie2 summary log, bcftools `.vcf.gz.stats`). bowtie2 stub emits its 3 tuple files + the new summary log.
- **Real run** (acceptance gate, `--email <real>`, `-profile docker -resume`): outcome documented in the PR thread / handback — MultiQC module parsing (fastp, qualimap, bcftools, bowtie2) is the human acceptance gate and will be re-verified independently before merge.
- `make ci`: the stub-wiring path passes. NOTE: on local Docker Desktop (macOS) the stub run is intermittently hit by a pre-existing runc "current working directory is outside of container mount namespace root -- possible container breakout detected" error on the **untouched** `run_qualimap` stub (exit 125 from the docker daemon, not the stub script). It is environmental/flaky (a clean `make ci` pass was observed) and does not occur on GitHub Actions (Ubuntu).

## Do not merge
Handing off for independent review + the real MultiQC-parsing run before merge.

https://claude.ai/code/session_01ApqSavpo9PW6RN5ohRMmdj
