### PR TITLE
Schema-based parameter validation (nf-schema + nextflow_schema.json)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
         with:
-          version: '23.04.0'
+          version: '25.04.8'
 
       - name: Verify pipeline parses and --help works
         run: nextflow run main.nf --help -profile docker -ansi-log false

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SRA Alignment Pipeline
 - [Output Data](#output-data)
 - [Pipeline Overview](#pipeline-overview)
 - [Usage](#usage)
+  - [Parameter Validation](#parameter-validation)
   - [Usage Examples](#usage-examples)
   - [Test the Pipeline](#test-the-pipeline)
   - [Post-Run Cleanup and Archiving](#post-run-cleanup-and-archiving)
@@ -24,10 +25,10 @@ SRA Alignment Pipeline
 
 ## Installation
 **Important:** Before you can use this pipeline, you need to install Nextflow and a supported container engine.
-- Nextflow can be installed by following the instructions [here](https://www.nextflow.io/docs/latest/getstarted.html). 
+- Nextflow (**version 25.04.8 or newer**, required by the `nf-schema` plugin used for parameter validation) can be installed by following the instructions [here](https://www.nextflow.io/docs/latest/getstarted.html). 
 - Docker can be installed by following the instructions [here](https://docs.docker.com/get-docker/). 
 - The pipeline selects its container/environment engine with `-profile` (Docker, Singularity, Apptainer, Podman, or experimental Conda). On HPC/cluster environments where the Docker daemon is not permitted, use `-profile singularity` or `-profile apptainer` (both pull the existing Docker images directly). See [Execution Profiles](#execution-profiles) for details.
-- This pipeline now resolves its runtime images from a tracked image manifest and has been modernized for current multi-architecture Docker builds. Local validation in this repository was performed with Nextflow 22.10.7 and Docker 29.x on arm64, and CI currently exercises Nextflow 23.04.0 on Ubuntu.
+- This pipeline resolves its runtime images from a tracked image manifest and has been modernized for current multi-architecture Docker builds. Parameters are validated declaratively via the `nf-schema` plugin (see [Parameter Validation](#parameter-validation)), which requires Nextflow 25.04 or newer. CI pins and exercises Nextflow 25.04.8 with Docker 29.x on Ubuntu.
 
 ## Input Data
 
@@ -138,6 +139,16 @@ OPTIONS:
 ```
 
 > **Tip:** The `-resume` flag tells Nextflow to reuse cached results from previous runs, skipping completed tasks. This is especially useful when a run fails partway through — re-running with `-resume` picks up where it left off.
+
+### Parameter Validation
+
+Pipeline parameters are validated declaratively using the [`nf-schema`](https://nextflow-io.github.io/nf-schema/) plugin, driven by `nextflow_schema.json`. On every run the pipeline:
+
+- checks each parameter's type and that required parameters are supplied (`--email` is required), reporting a clear error for invalid values (for example, a non-integer `--cpus`);
+- reports any unrecognized `--parameter`;
+- generates the `--help` output directly from the schema, so `nextflow run main.nf --help` always lists the current parameters with their types, defaults, and descriptions.
+
+One cross-field rule that a JSON schema cannot express is enforced in `main.nf`: you must provide **either** `--input_file` **or** both `--sra_accession` and `--identifier`.
 
 ## Usage Examples
 ### **Option #1: Run from Github**

--- a/conf/base.config
+++ b/conf/base.config
@@ -14,8 +14,9 @@
  * folded into the cpu cap (see check_max below), so `--cpus 1` forces every task
  * to a single core exactly as before.
  *
- * NOTE: This uses the PLAIN Groovy helper on purpose (no nf-schema plugin), so
- * it works on the local Nextflow 22.10.7.
+ * NOTE: check_max() is a plain-Groovy helper and does NOT depend on the
+ * nf-schema plugin (which drives parameter validation in main.nf). Keeping
+ * resource capping self-contained avoids coupling it to the plugin.
  */
 
 process {

--- a/main.nf
+++ b/main.nf
@@ -1,6 +1,11 @@
 import groovy.json.JsonException
 import groovy.json.JsonSlurper
 
+// nf-schema drives declarative parameter validation and schema-generated --help
+// from nextflow_schema.json. This replaces the former hand-rolled
+// `if (params.x == '') error(...)` cascade. See nextflow.config for the plugin pin.
+include { validateParameters; paramsHelp } from 'plugin/nf-schema'
+
 final List REQUIRED_RUNTIME_IMAGE_KEYS = [
     'aria2',
     'bcftools',
@@ -108,77 +113,35 @@ def resolvedContainerImages = buildContainerImageMap(
     resolvedContainerNamespace
 )
 
+// Schema-generated help (params, types, defaults, and descriptions all come
+// from nextflow_schema.json). Note: -profile is a Nextflow core option, not a
+// pipeline param, so it is documented in README.md rather than the schema.
 if (params.help) {
-    log.info """
-    ======================
-    SRA Alignment Pipeline
-    ======================
-
-    Usage:
-      nextflow run main.nf -profile docker [OPTIONS]
-      nextflow run https://github.com/eoksen/sra_alignment_pipeline -r main -profile docker [OPTIONS]
-
-    Execution profile (required to run processes; choose ONE engine):
-      -profile docker           Run processes with Docker (default documented engine)
-      -profile singularity      Run processes with Singularity (HPC; autoMounts enabled)
-      -profile apptainer        Run processes with Apptainer (HPC; autoMounts enabled)
-      -profile conda            EXPERIMENTAL, pending biocontainers migration (issue #32)
-      -profile podman           Run processes with Podman
-
-    Required:
-      --email <address>         NCBI-registered email address
-      --cpus <int>              Upper cap on per-process CPUs (default: 2). Per-process
-                                requests come from resource labels; --cpus caps them
-                                (e.g. --cpus 1 forces every task to a single core).
-
-    Input (one required):
-      --sra_accession <id>      SRA accession number (requires --identifier)
-      --identifier <id>         NCBI nucleotide identifier for reference genome
-      --input_file <path>       CSV with columns: sra_accession, identifier
-
-    Optional:
-      --outdir <path>           Directory for all published outputs and execution
-                                reports (default: results)
-      --max_cpus <int>          Cap on CPUs any single process may request (default: 8)
-      --max_memory <str>        Cap on memory any single process may request (default: 16.GB)
-      --max_time <str>          Cap on wall time any single process may request (default: 24.h)
-      --image_manifest <path>   Path to the tracked container image manifest
-      --container_registry <r>  Override the container registry from the manifest
-      --container_namespace <n> Override the container namespace from the manifest
-      --L <int>                 Bowtie2 seed length (default: 22)
-      --X <int>                 Bowtie2 max insert size (default: 600)
-      --ploidy <int>            Ploidy for variant calling (default: 1)
-      --include <expr>          bcftools filter inclusion expression
-      --exclude <expr>          bcftools filter exclusion expression
-      --help                    Show this help message
-    """.stripIndent()
+    log.info paramsHelp(command: "nextflow run main.nf -profile docker --input_file <csv> --email <ncbi-email>")
     exit 0
 }
 
-// If no SRA accession number, identifier, or input file is provided, throw an error.
-if ( params.sra_accession == '' && params.identifier == '' && params.input_file == '' ) {
-    error "You must provide either an SRA accession number and identifier with --sra_accession and --identifier, or an input file with --input_file"
+// Declarative parameter validation against nextflow_schema.json. This enforces
+// the checks that were previously hand-rolled: --email is required, --cpus (and
+// the other integer params) must be integers, and any unrecognized param is
+// reported. Replaces the former `if (params.x == '') error(...)` cascade.
+validateParameters()
+
+// Residual cross-field check that a JSON schema cannot express: the pipeline
+// needs EITHER --input_file OR (--sra_accession AND --identifier). nf-schema
+// validates each param independently but not this XOR-style dependency across
+// three params, so it stays as explicit Groovy. (This single condition covers
+// both "nothing provided" and "only one of accession/identifier provided".)
+if ( params.input_file == '' && ( params.sra_accession == '' || params.identifier == '' ) ) {
+    error("You must provide either an SRA accession number and identifier (--sra_accession and --identifier), or an input file (--input_file).")
 }
 
-// If only one of the SRA accession or identifier is provided without an input file, throw an error.
-if (( params.sra_accession == '' || params.identifier == '' ) && params.input_file == '' ) {
-    error("You have only provided one of the SRA accession or identifier. Both or an input file must be provided. \nCorrect usage: nextflow run main.nf --sra_accession <accession> --identifier <identifier> --cpus <cpus> --email <email> \nOr provide an input file: nextflow run main.nf --input_file <file> --cpus <cpus> --email <email>")
-}
-
-// If both an input file and individual SRA accession and/or identifier are provided, log a warning that only the input file will be used.
-if ( params.input_file != '' && ( params.sra_accession != '' || params.identifier != '' )) {
+// If both an input file and an individual SRA accession/identifier are given,
+// only the input file is used.
+if ( params.input_file != '' && ( params.sra_accession != '' || params.identifier != '' ) ) {
     log.warn("Both an input file and individual SRA accession and/or identifier are provided. Only the input file will be used for the pipeline.")
 }
 
-// If no email is provided, throw an error. 
-if ( params.email == '' ) {
-    error("No email provided. Specify it with --email. \nCorrect usage: nextflow run main.nf --sra_accession <accession> --identifier <identifier> --cpus <cpus> --email <email>")
-}
-
-// If the provided CPU number is not a number, throw an error.
-if ( !params.cpus.toString().isNumber() ) {
-    error("Invalid CPU number provided. Specify it with --cpus <int>. It should be an integer. \nTo check the number of CPUs on your system: \n- Unix-based (Linux/MacOS/WSL2): use the 'nproc' command \n- To adjust system cpu and memory allocation for Docker, go to Docker Desktop, then settings/resources and set cpu and memory parameters. \nnextflow run main.nf --sra_accession <accession> --identifier <identifier> --cpus <cpus> --email <email>")
-}
 log.info("Using container images from ${resolvedContainerRegistry}/${resolvedContainerNamespace}")
 
 include { get_srrs } from './nf_scripts/get_srrs' addParams(container_image: resolvedContainerImages['sra_parser'])

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,12 @@
 nextflow.enable.dsl=2
 
+// nf-schema drives declarative parameter validation and schema-generated --help
+// from nextflow_schema.json (see main.nf: validateParameters()/paramsHelp()).
+// Pinned to 2.5.x, which requires Nextflow >=25.04 (this repo pins 25.04.8).
+plugins {
+    id 'nf-schema@2.5.1'
+}
+
 includeConfig 'conf/params.config'
 includeConfig 'conf/base.config'
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,0 +1,177 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/eoksen/sra_alignment_pipeline/main/nextflow_schema.json",
+    "title": "sra_alignment_pipeline pipeline parameters",
+    "description": "Align sequence data from the SRA to an NCBI reference genome and call variants.",
+    "type": "object",
+    "$defs": {
+        "required_options": {
+            "title": "Required options",
+            "type": "object",
+            "description": "Options that must be supplied for every run.",
+            "required": ["email"],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "description": "NCBI-registered email address. Required for NCBI/Entrez access.",
+                    "help_text": "Providing an email address is required when accessing the NCBI services this pipeline depends on. Register one at https://account.ncbi.nlm.nih.gov."
+                },
+                "cpus": {
+                    "type": "integer",
+                    "default": 2,
+                    "minimum": 1,
+                    "description": "Upper cap on per-process CPUs (default: 2).",
+                    "help_text": "Per-process requests come from nf-core-style resource labels; --cpus caps them (e.g. --cpus 1 forces every task to a single core). Bounded by the CPUs your container engine is allowed to use."
+                }
+            }
+        },
+        "input_options": {
+            "title": "Input options",
+            "type": "object",
+            "description": "Provide either --input_file, or both --sra_accession and --identifier.",
+            "properties": {
+                "sra_accession": {
+                    "type": "string",
+                    "default": "",
+                    "description": "SRA accession number (requires --identifier).",
+                    "help_text": "Any SRA accession type can be used (SRR/ERR/DRR, SRX/ERX/DRX, SRP/ERP/DRP, etc.). Up to 20 SRRs associated with the accession are downloaded."
+                },
+                "identifier": {
+                    "type": "string",
+                    "default": "",
+                    "description": "NCBI nucleotide identifier for the reference genome (requires --sra_accession).",
+                    "help_text": "Entrez nucleotide identifier for the reference genome FASTA, e.g. NC_000866.4, CP014314.1. Only one identifier can be provided and is used for all SRRs of the accession."
+                },
+                "input_file": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to a CSV with columns: sra_accession, identifier.",
+                    "help_text": "A CSV file with two columns (column 1: sra_accession, column 2: identifier). When provided, it takes precedence over --sra_accession/--identifier."
+                }
+            }
+        },
+        "output_options": {
+            "title": "Output options",
+            "type": "object",
+            "description": "Where published outputs and execution reports are written.",
+            "properties": {
+                "outdir": {
+                    "type": "string",
+                    "default": "results",
+                    "description": "Directory for all published outputs and execution reports (default: results).",
+                    "help_text": "Every publishDir output plus the report/timeline/trace files are written under this directory, so runs can be kept separate."
+                }
+            }
+        },
+        "resource_options": {
+            "title": "Resource options",
+            "type": "object",
+            "description": "Laptop-sane ceilings that cap what any single process may request.",
+            "properties": {
+                "max_cpus": {
+                    "type": "integer",
+                    "default": 8,
+                    "minimum": 1,
+                    "description": "Cap on CPUs any single process may request (default: 8)."
+                },
+                "max_memory": {
+                    "type": "string",
+                    "default": "16.GB",
+                    "description": "Cap on memory any single process may request (default: 16.GB).",
+                    "help_text": "Use a Nextflow memory string such as '16.GB' or '32.GB'."
+                },
+                "max_time": {
+                    "type": "string",
+                    "default": "24.h",
+                    "description": "Cap on wall time any single process may request (default: 24.h).",
+                    "help_text": "Use a Nextflow duration string such as '24.h' or '2.d'."
+                }
+            }
+        },
+        "container_options": {
+            "title": "Container options",
+            "type": "object",
+            "description": "Control which container images the pipeline resolves at runtime.",
+            "properties": {
+                "image_manifest": {
+                    "type": "string",
+                    "default": "conf/images.json",
+                    "description": "Path to the tracked container image manifest (default: conf/images.json)."
+                },
+                "container_registry": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Override the container registry from the manifest."
+                },
+                "container_namespace": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Override the container namespace from the manifest."
+                }
+            }
+        },
+        "alignment_and_variant_calling_options": {
+            "title": "Alignment and variant-calling options",
+            "type": "object",
+            "description": "Tuning for bowtie2 alignment and bcftools variant calling/filtering.",
+            "properties": {
+                "L": {
+                    "type": "integer",
+                    "default": 22,
+                    "description": "Bowtie2 seed length (default: 22).",
+                    "help_text": "Length of the seed substrings to align during multiseed alignment. Smaller values make alignment slower but more sensitive. Must be smaller than the read length."
+                },
+                "X": {
+                    "type": "integer",
+                    "default": 600,
+                    "description": "Bowtie2 max insert size (default: 600).",
+                    "help_text": "The maximum fragment length for valid paired-end alignments."
+                },
+                "ploidy": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "Ploidy for variant calling (default: 1)."
+                },
+                "include": {
+                    "type": "string",
+                    "default": "",
+                    "description": "bcftools filter inclusion expression.",
+                    "help_text": "Providing --include or --exclude enables the run_bcftools_filter step. Use a bcftools filter expression in single quotes, e.g. 'DP>200'."
+                },
+                "exclude": {
+                    "type": "string",
+                    "default": "",
+                    "description": "bcftools filter exclusion expression.",
+                    "help_text": "Providing --include or --exclude enables the run_bcftools_filter step. Use a bcftools filter expression in single quotes."
+                }
+            }
+        },
+        "generic_options": {
+            "title": "Generic options",
+            "type": "object",
+            "description": "Less commonly used options.",
+            "properties": {
+                "help": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Show the help message (schema-generated) and exit.",
+                    "hidden": true
+                },
+                "container_image": {
+                    "type": "string",
+                    "description": "Internal: per-process container image reference injected into each module via addParams(); not intended to be set on the command line.",
+                    "hidden": true
+                }
+            }
+        }
+    },
+    "allOf": [
+        { "$ref": "#/$defs/required_options" },
+        { "$ref": "#/$defs/input_options" },
+        { "$ref": "#/$defs/output_options" },
+        { "$ref": "#/$defs/resource_options" },
+        { "$ref": "#/$defs/container_options" },
+        { "$ref": "#/$defs/alignment_and_variant_calling_options" },
+        { "$ref": "#/$defs/generic_options" }
+    ]
+}


### PR DESCRIPTION
Closes #31

Replaces the hand-rolled `if (params.x == '') error(...)` validation cascade in `main.nf` with declarative, schema-driven validation using the **nf-schema** plugin and a new `nextflow_schema.json`. This is the nf-core convention: validates types/required/unrecognized params and auto-generates `--help` from the schema.

## Nextflow / plugin versions
- **Pins Nextflow to `25.04.8`** (CI `.github/workflows/ci.yml`, README). nf-schema needs Nextflow >= 23.10; the 2.5.x line requires >= 25.04.
- **nf-schema `2.5.1`** — latest 2.x resolvable in the Nextflow plugins registry that targets Nextflow 25.04 (2.5.0/2.5.1 require `>=25.04.0`; 2.6+/2.7+ target newer Nextflow and aren't in the resolvable index). Confirmed it downloads and runs under 25.04.8.

## `addParams`-under-25.04.8 determination (critical first step)
Ran the **current, unchanged** pipeline under a freshly installed 25.04.8 launcher. Result: **scenario (a) — WARNS and runs.** The 12 `include { X } from '...' addParams(container_image: ...)` statements emit:

```
WARN: Include with `addParams()` is deprecated -- pass params as a workflow or process input instead
```

...and the stub run still completes (exit 0, all processes submitted). Per the plan, `addParams` is therefore **left as-is in this PR** (not migrated). Migrating off `addParams` overlaps the container-resolution rework in **#32** and is deferred there.

## What changed
- `nextflow.config`: add `plugins { id 'nf-schema@2.5.1' }`.
- `nextflow_schema.json` (new): describes all 18 params grouped into help sections — `email` (required), `cpus`, `sra_accession`, `identifier`, `input_file`, `outdir`, `max_cpus`, `max_memory`, `max_time`, `image_manifest`, `container_registry`, `container_namespace`, `L`, `X`, `ploidy`, `include`, `exclude`, `help`. The internal `container_image` (injected per-module via `addParams`) and `help` are marked `hidden`, so validation never flags them.
- `main.nf`: `include { validateParameters; paramsHelp } from 'plugin/nf-schema'`; `--help` now via `paramsHelp(command: ...)`; `validateParameters()` replaces the email-required / cpus-numeric / "only one of accession-identifier" checks.
- `.github/workflows/ci.yml`: Nextflow pin `23.04.0` → `25.04.8`.
- `README.md` / `conf/base.config`: version references + nf-schema documentation.

## Kept intentionally
- **Cross-field XOR check** `input_file OR (sra_accession AND identifier)` — a JSON schema can't express this dependency; it stays as explicit Groovy (documented inline). The single condition also covers the "nothing provided" case.
- **Custom image-manifest validation** (`loadImageManifest`/`validateImageManifest`/…) — untouched. It still runs *before* help/validation, so the CI error-string assertions (`Invalid container image manifest`, `top-level JSON value must be an object`, `defaults must be an object`, `images.bcftools must be an object`) are unaffected.

## Decisions
- **`email` default stays `''`** (no change to `conf/params.config`): empirically, nf-schema 2.5.1 treats an empty-string default as "missing" for a `required` param, so check #3 passes without switching the default to `null`.
- **`assets/schema_input.json` skipped** — the CSV is parsed by `parse_srrs`/`get_srrs`; wiring `samplesheetToList` would replace that logic and is out of scope (issue marks it optional).

## Validation evidence (all local runs `NXF_VER=25.04.8 ./nextflow`)
1. `python3 -c "import json; json.load(open('nextflow_schema.json'))"` — valid JSON. ✔
2. `--help` — schema-generated, grouped, lists every param with type/default/description, **exit 0**. ✔
3. Missing `--email` → **exit 1**, `* Missing required parameter(s): email`. ✔
4. `--cpus abc` → **exit 1**, `* --cpus (abc): Value is [string] but should be [integer]`. ✔
5. Valid stub run (`--input_file test_data/phage_smoke.csv --cpus 1 --email … -stub-run`) — **exit 0**, all processes submitted end-to-end. ✔
6. `make manifest-validation` — **exit 0**; all four exact manifest error strings still present. ✔
7. Old cascade removed (`No email provided`, `Invalid CPU number`, `You have only provided one` all gone); XOR `You must provide either …` retained; `validateParameters()` present. ✔
8. `make ci` — **exit 0** (pipeline-check + manifest-validation + manifest-stub + image-manifest-tests + build-images-tests).

## Follow-ups
- Migrate off deprecated `addParams`-on-include (fold into container-resolution rework, **#32**).
- `nf-schema` 2.6/2.7 exist but target newer Nextflow; revisit when the pin moves past 25.04.

https://claude.ai/code/session_01ApqSavpo9PW6RN5ohRMmdj