### PR TITLE
fix(config): require Nextflow 25.04 or newer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 SHELL := /bin/bash
 
-.PHONY: help ci pipeline-check manifest-validation manifest-stub image-manifest-tests build-images-tests clean-ci-artifacts
+.PHONY: help ci nextflow-version-check pipeline-check manifest-validation manifest-stub image-manifest-tests build-images-tests clean-ci-artifacts
 
 help:
 	@echo "Local CI targets:"
 	@echo "  make ci                   Run the local equivalent of GitHub Actions CI"
+	@echo "  make nextflow-version-check Verify the minimum Nextflow version constraint"
 	@echo "  make pipeline-check       Verify Nextflow parses and --help works"
 	@echo "  make manifest-validation  Exercise manifest validation failures"
 	@echo "  make manifest-stub        Verify manifest-derived refs in a stub run"
@@ -12,7 +13,13 @@ help:
 	@echo "  make build-images-tests   Run build_images orchestration checks"
 	@echo "  make clean-ci-artifacts   Remove local Nextflow CI artifacts"
 
-ci: pipeline-check manifest-validation manifest-stub image-manifest-tests build-images-tests
+ci: nextflow-version-check pipeline-check manifest-validation manifest-stub image-manifest-tests build-images-tests
+
+nextflow-version-check:
+	@grep -Eq "^[[:space:]]*nextflowVersion[[:space:]]*=[[:space:]]*['\"]!>=25\\.04\\.0['\"]" nextflow.config || { \
+		echo "nextflow.config must require Nextflow >=25.04.0 via manifest.nextflowVersion" >&2; \
+		exit 1; \
+	}
 
 pipeline-check:
 	nextflow run main.nf --help -profile docker -ansi-log false

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ SRA Alignment Pipeline
 - The pipeline selects its container/environment engine with `-profile` (Docker, Singularity, Apptainer, Podman, or experimental Conda). On HPC/cluster environments where the Docker daemon is not permitted, use `-profile singularity` or `-profile apptainer` (both pull the existing Docker images directly). See [Execution Profiles](#execution-profiles) for details.
 - This pipeline resolves its runtime images from a tracked image manifest and has been modernized for current multi-architecture Docker builds. Parameters are validated declaratively via the `nf-schema` plugin (see [Parameter Validation](#parameter-validation)), which requires Nextflow 25.04 or newer. CI pins and exercises Nextflow 25.04.8 with Docker 29.x on Ubuntu.
 
+The repository's `make` targets call the `nextflow` executable installed in your current environment; they do not download the CI-pinned version. Before running `make ci`, confirm that `nextflow -version` reports Nextflow 25.04 or newer. Older versions stop immediately with the pipeline's minimum-version requirement instead of attempting plugin resolution.
+
 ## Input Data
 
 The pipeline accepts input data in two ways:

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,9 @@
 nextflow.enable.dsl=2
 
+manifest {
+    nextflowVersion = '!>=25.04.0'
+}
+
 // nf-schema drives declarative parameter validation and schema-generated --help
 // from nextflow_schema.json (see main.nf: validateParameters()/paramsHelp()).
 // Pinned to 2.5.x, which requires Nextflow >=25.04 (this repo pins 25.04.8).


### PR DESCRIPTION
## Summary
- declare the nf-core-style Nextflow 25.04 minimum in the pipeline manifest
- keep the version constraint covered by the local CI target
- document that local Make targets use the ambient Nextflow installation

## Test plan
- [x] `make nextflow-version-check`
- [x] ambient Nextflow 22.10.7: `nextflow run main.nf --help -profile docker -ansi-log false` exits 1 with `requires Nextflow version >=25.04.0`
- [x] Nextflow 25.04.8: `make pipeline-check`
- [x] Nextflow 25.04.8: `make ci`
- [x] `git diff --check`

Closes #41