### PR TITLE
feat: add shared reference genome cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
             exit 1
           fi
 
+      - name: Verify shared reference cache reuse
+        run: bash scripts/test_reference_cache.sh
+
       - name: Run image manifest regression checks
         run: scripts/test_image_manifest.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help ci nextflow-version-check pipeline-check manifest-validation manifest-stub image-manifest-tests build-images-tests clean-ci-artifacts
+.PHONY: help ci nextflow-version-check pipeline-check manifest-validation manifest-stub reference-cache-tests image-manifest-tests build-images-tests clean-ci-artifacts
 
 help:
 	@echo "Local CI targets:"
@@ -9,11 +9,12 @@ help:
 	@echo "  make pipeline-check       Verify Nextflow parses and --help works"
 	@echo "  make manifest-validation  Exercise manifest validation failures"
 	@echo "  make manifest-stub        Verify manifest-derived refs in a stub run"
+	@echo "  make reference-cache-tests Verify reference reuse across output directories"
 	@echo "  make image-manifest-tests Run Python manifest regression checks"
 	@echo "  make build-images-tests   Run build_images orchestration checks"
 	@echo "  make clean-ci-artifacts   Remove local Nextflow CI artifacts"
 
-ci: nextflow-version-check pipeline-check manifest-validation manifest-stub image-manifest-tests build-images-tests
+ci: nextflow-version-check pipeline-check manifest-validation manifest-stub reference-cache-tests image-manifest-tests build-images-tests
 
 nextflow-version-check:
 	@grep -Eq "^[[:space:]]*nextflowVersion[[:space:]]*=[[:space:]]*['\"]!>=25\\.04\\.0['\"]" nextflow.config || { \
@@ -69,6 +70,9 @@ manifest-validation:
 manifest-stub: clean-ci-artifacts
 	nextflow run main.nf --input_file test_data/phage_smoke.csv --cpus 1 --email test@example.com -profile docker -stub-run -ansi-log false
 	grep -R --fixed-strings --quiet "quay.io/biocontainers/fastp:1.3.0--h43da1c4_0" work/*/*/.command.run
+
+reference-cache-tests:
+	bash scripts/test_reference_cache.sh
 
 image-manifest-tests:
 	bash scripts/test_image_manifest.sh

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ OPTIONS:
 
 --outdir <path> Directory for all published outputs and execution reports, default: `results`. Every `publishDir` output and the report/timeline/trace files are written under this directory, so runs can be kept separate.
 
+--reference_cache <path> Directory used to cache downloaded reference genomes, default: `<outdir>/reference_genomes`. Set this to a shared path to reuse the same reference download across runs with different `--outdir` values.
+
 --max_cpus <int> Maximum CPUs any single process may request, default: 8.
 
 --max_memory <str> Maximum memory any single process may request, default: `16.GB`.
@@ -141,6 +143,20 @@ OPTIONS:
 ```
 
 > **Tip:** The `-resume` flag tells Nextflow to reuse cached results from previous runs, skipping completed tasks. This is especially useful when a run fails partway through — re-running with `-resume` picks up where it left off.
+
+### Reusing Reference Genomes Across Runs
+
+By default, downloaded reference genomes are cached in `<outdir>/reference_genomes`, preserving the pipeline's existing self-contained output layout. To share references across runs that use different output directories, pass the same `--reference_cache` path to each run:
+
+```bash
+nextflow run main.nf -profile docker --input_file samples-a.csv --email <ncbi-email-address> \
+    --outdir results/run-a --reference_cache /data/sra-reference-cache
+
+nextflow run main.nf -profile docker --input_file samples-b.csv --email <ncbi-email-address> \
+    --outdir results/run-b --reference_cache /data/sra-reference-cache
+```
+
+When both runs request the same NCBI identifier, the second run reuses the cached FASTA instead of downloading it again. The shared cache is intentionally outside either output directory, so removing or archiving one run does not remove the cached reference.
 
 ### Parameter Validation
 

--- a/conf/params.config
+++ b/conf/params.config
@@ -13,6 +13,7 @@ params {
 
     // output location
     outdir = 'results' // base directory for all published outputs and execution reports (default preserves prior behavior)
+    reference_cache = '' // shared reference genome cache; defaults dynamically to <outdir>/reference_genomes
     image_manifest = 'conf/images.json' // tracked container image manifest
     container_registry = '' // override the default registry defined in the image manifest
     container_namespace = '' // override the default namespace defined in the image manifest

--- a/main.nf
+++ b/main.nf
@@ -127,6 +127,14 @@ if (params.help) {
 // reported. Replaces the former `if (params.x == '') error(...)` cascade.
 validateParameters()
 
+// Resolve this default after command-line parameters have been applied so that
+// `--outdir custom-results` implies `custom-results/reference_genomes`. An
+// explicit --reference_cache remains independent of --outdir and can therefore
+// be reused by otherwise isolated runs.
+if (!params.reference_cache?.toString()?.trim()) {
+    params.reference_cache = "${params.outdir}/reference_genomes"
+}
+
 // Residual cross-field check that a JSON schema cannot express: the pipeline
 // needs EITHER --input_file OR (--sra_accession AND --identifier). nf-schema
 // validates each param independently but not this XOR-style dependency across
@@ -143,6 +151,7 @@ if ( params.input_file != '' && ( params.sra_accession != '' || params.identifie
 }
 
 log.info("Using container images from ${resolvedContainerRegistry}/${resolvedContainerNamespace}")
+log.info("Using reference genome cache at ${params.reference_cache}")
 
 include { get_srrs } from './nf_scripts/get_srrs' addParams(container_image: resolvedContainerImages['sra_parser'])
 include { parse_srrs } from './nf_scripts/parse_srrs' addParams(container_image: resolvedContainerImages['sra_parser'])

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -60,6 +60,11 @@
                     "default": "results",
                     "description": "Directory for all published outputs and execution reports (default: results).",
                     "help_text": "Every publishDir output plus the report/timeline/trace files are written under this directory, so runs can be kept separate."
+                },
+                "reference_cache": {
+                    "type": "string",
+                    "description": "Directory used to cache downloaded reference genomes (default: <outdir>/reference_genomes).",
+                    "help_text": "Defaults to <outdir>/reference_genomes. Set this to a shared path to reuse reference downloads across runs with different --outdir values."
                 }
             }
         },

--- a/nf_scripts/download_fasta.nf
+++ b/nf_scripts/download_fasta.nf
@@ -3,7 +3,7 @@ process download_fasta {
     maxForks 1
     container "${params.container_image}"
 
-    storeDir "${params.outdir}/reference_genomes"
+    storeDir params.reference_cache
 
     input:
     val sra_accession

--- a/scripts/test_reference_cache.sh
+++ b/scripts/test_reference_cache.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+shared_cache="$test_root/shared-reference-cache"
+counter_file="$test_root/download-count"
+export REFERENCE_DOWNLOAD_COUNTER="$counter_file"
+export PATH="$repo_root/tests/reference_cache/bin:$PATH"
+
+run_pipeline() {
+    local outdir="$1"
+    nextflow -C "$repo_root/tests/reference_cache/nextflow.config" \
+        run "$repo_root/tests/reference_cache/main.nf" \
+        --reference_cache "$shared_cache" \
+        --outdir "$outdir" \
+        -work-dir "$test_root/work" \
+        -ansi-log false
+}
+
+run_pipeline "$test_root/run-a"
+[[ "$(< "$counter_file")" == "1" ]]
+[[ -s "$shared_cache/NC_TEST.1_reference.fasta.gz" ]]
+
+run_pipeline "$test_root/run-b"
+[[ "$(< "$counter_file")" == "1" ]] || {
+    echo "Reference downloader ran more than once despite a shared --reference_cache." >&2
+    exit 1
+}
+
+jq -e '.["$defs"].output_options.properties.reference_cache.type == "string"' \
+    "$repo_root/nextflow_schema.json" >/dev/null
+grep -Fq 'reference_cache = "${params.outdir}/reference_genomes"' "$repo_root/main.nf"
+grep -Fq 'storeDir params.reference_cache' "$repo_root/nf_scripts/download_fasta.nf"
+if grep -rn 'results/' "$repo_root/nf_scripts"; then
+    echo "Found a hard-coded results/ path in nf_scripts." >&2
+    exit 1
+fi
+
+echo "Reference cache reused across distinct output directories."

--- a/tests/reference_cache/bin/download_fasta.py
+++ b/tests/reference_cache/bin/download_fasta.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+identifier="$1"
+counter_file="${REFERENCE_DOWNLOAD_COUNTER:?REFERENCE_DOWNLOAD_COUNTER must be set}"
+count=0
+if [[ -f "$counter_file" ]]; then
+    read -r count < "$counter_file"
+fi
+printf '%s\n' "$((count + 1))" > "$counter_file"
+printf '>stub-reference\nACGT\n' | gzip > "${identifier}_reference.fasta.gz"

--- a/tests/reference_cache/main.nf
+++ b/tests/reference_cache/main.nf
@@ -1,0 +1,11 @@
+nextflow.enable.dsl = 2
+
+include { download_fasta } from '../../nf_scripts/download_fasta' addParams(container_image: 'unused-in-local-test')
+
+workflow {
+    download_fasta(
+        Channel.value('SRR_TEST'),
+        Channel.value('NC_TEST.1'),
+        Channel.value('test@example.com')
+    )
+}

--- a/tests/reference_cache/nextflow.config
+++ b/tests/reference_cache/nextflow.config
@@ -1,0 +1,1 @@
+process.executor = 'local'


### PR DESCRIPTION
## Summary
- add `--reference_cache`, dynamically defaulting to `<outdir>/reference_genomes`
- use the configured cache as the `download_fasta` `storeDir`
- document shared-cache usage in schema-generated help and README
- add a deterministic two-run regression test proving one download across distinct output directories

## Verification
- `make reference-cache-tests nextflow-version-check image-manifest-tests build-images-tests`
- `bash -n scripts/test_reference_cache.sh tests/reference_cache/bin/download_fasta.py`
- `python3 -m json.tool nextflow_schema.json`
- `git diff --check`
- `grep -rn results/ nf_scripts` (no matches)

Closes #37