### PR TITLE
fix: harden reference caching and FASTQ fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Verify shared reference cache reuse
         run: bash scripts/test_reference_cache.sh
 
+      - name: Verify paired download fallback routing
+        run: bash scripts/test_download_fallback.sh
+
       - name: Run image manifest regression checks
         run: scripts/test_image_manifest.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help ci nextflow-version-check pipeline-check manifest-validation manifest-stub reference-cache-tests image-manifest-tests build-images-tests clean-ci-artifacts
+.PHONY: help ci nextflow-version-check pipeline-check manifest-validation manifest-stub reference-cache-tests download-fallback-tests image-manifest-tests build-images-tests clean-ci-artifacts
 
 help:
 	@echo "Local CI targets:"
@@ -10,11 +10,12 @@ help:
 	@echo "  make manifest-validation  Exercise manifest validation failures"
 	@echo "  make manifest-stub        Verify manifest-derived refs in a stub run"
 	@echo "  make reference-cache-tests Verify reference reuse across output directories"
+	@echo "  make download-fallback-tests Verify paired ENA downloads and SRA fallback routing"
 	@echo "  make image-manifest-tests Run Python manifest regression checks"
 	@echo "  make build-images-tests   Run build_images orchestration checks"
 	@echo "  make clean-ci-artifacts   Remove local Nextflow CI artifacts"
 
-ci: nextflow-version-check pipeline-check manifest-validation manifest-stub reference-cache-tests image-manifest-tests build-images-tests
+ci: nextflow-version-check pipeline-check manifest-validation manifest-stub reference-cache-tests download-fallback-tests image-manifest-tests build-images-tests
 
 nextflow-version-check:
 	@grep -Eq "^[[:space:]]*nextflowVersion[[:space:]]*=[[:space:]]*['\"]!>=25\\.04\\.0['\"]" nextflow.config || { \
@@ -73,6 +74,9 @@ manifest-stub: clean-ci-artifacts
 
 reference-cache-tests:
 	bash scripts/test_reference_cache.sh
+
+download-fallback-tests:
+	bash scripts/test_download_fallback.sh
 
 image-manifest-tests:
 	bash scripts/test_image_manifest.sh

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Please note the following:
 - For accessions with multiple SRRs, the given identifier will be associated with all SRRs (up to a maximum of 20).
 - If you need to extract more than 20 SRRs from a given SRA accession, please use [SRA-Explorer](https://sra-explorer.info/) or other appropriate tools.
 - To find an appropriate NCBI reference genome identifier, visit [NCBI Nucleotide](https://www.ncbi.nlm.nih.gov/nuccore) and perform a search like: "organism_name"[Organism] AND genome[All Fields].
+- The pipeline currently supports paired-end sequencing runs only. If neither ENA nor the SRA Toolkit fallback produces both read mates, the run fails with a clear error instead of silently dropping the sample. Single-end runs are not yet supported downstream.
 
 If both command line and CSV inputs are provided, the pipeline defaults to the CSV. The pipeline requires either command line or CSV input to run.
 

--- a/bin/sra_download.sh
+++ b/bin/sra_download.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -u
 
 accession="$1"
 
@@ -19,30 +21,46 @@ echo "$ftp_link_2"
 echo "$ftp_link_3"
 echo "$ftp_link_4"
 
-if [ ! -f "${accession}_1.fastq.gz" ]; then
-    aria2c -x3 -s3 "$ftp_link_1" || echo "Download from ${ftp_link_1} failed"
-else
-    echo "File ${accession}_1.fastq.gz already exists, download not attempted."
+download_mate() {
+    local target="$1"
+    local primary_url="$2"
+    local alternate_url="$3"
+
+    if [[ -s "$target" && ! -e "${target}.aria2" ]]; then
+        echo "File ${target} already exists, download not attempted."
+        return 0
+    fi
+
+    rm -f "$target" "${target}.aria2"
+    if aria2c -x3 -s3 "$primary_url" && [[ -s "$target" && ! -e "${target}.aria2" ]]; then
+        return 0
+    fi
+
+    echo "Download from ${primary_url} failed"
+    rm -f "$target" "${target}.aria2"
+    if aria2c -x3 -s3 "$alternate_url" && [[ -s "$target" && ! -e "${target}.aria2" ]]; then
+        return 0
+    fi
+
+    echo "Download from ${alternate_url} failed"
+    rm -f "$target" "${target}.aria2"
+    return 1
+}
+
+forward_ok=false
+reverse_ok=false
+if download_mate "${accession}_1.fastq.gz" "$ftp_link_1" "$ftp_link_3"; then
+    forward_ok=true
+fi
+if download_mate "${accession}_2.fastq.gz" "$ftp_link_2" "$ftp_link_4"; then
+    reverse_ok=true
 fi
 
-if [ ! -f "${accession}_2.fastq.gz" ]; then
-    aria2c -x3 -s3 "$ftp_link_2" || echo "Download from ${ftp_link_2} failed"
+status_file="${accession}.txt"
+if [[ "$forward_ok" == true && "$reverse_ok" == true ]]; then
+    rm -f "$status_file"
 else
-    echo "File ${accession}_2.fastq.gz already exists, download not attempted."
-fi
-
-if [ ! -f "${accession}_1.fastq.gz" ]; then
-    aria2c -x3 -s3 "$ftp_link_3" || echo "Download from ${ftp_link_3} failed"
-else
-    echo "File ${accession}_1.fastq.gz already exists, download not attempted."
-fi
-
-if [ ! -f "${accession}_2.fastq.gz" ]; then
-    aria2c -x3 -s3 "$ftp_link_4" || echo "Download from ${ftp_link_4} failed"
-else
-    echo "File ${accession}_2.fastq.gz already exists, download not attempted."
-fi
-
-if [ ! -f "${accession}_1.fastq.gz" ]; then
-    echo "Download failed for ${accession}" > ${accession}.txt
+    rm -f "${accession}_1.fastq.gz" "${accession}_1.fastq.gz.aria2"
+    rm -f "${accession}_2.fastq.gz" "${accession}_2.fastq.gz.aria2"
+    printf 'ENA download unavailable; use SRA Toolkit fallback for %s\n' "$accession" > "$status_file"
 fi

--- a/conf/base.config
+++ b/conf/base.config
@@ -55,13 +55,6 @@ process {
         time   = { check_max( 8.h   * task.attempt, 'time'   ) }
     }
 
-    // download_fastq intentionally keeps `errorStrategy 'ignore'` (defined in the
-    // module): an ENA FTP miss is expected and must fall through to the
-    // fasterq-dump path, not fail the run. withName has the highest precedence,
-    // so this guarantees the ignore semantics regardless of directive-precedence.
-    withName:download_fastq {
-        errorStrategy = 'ignore'
-    }
 }
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -193,7 +193,7 @@ workflow {
         
         // run only when download_status is emitted from download_fastq
         run_fasterq_dump( download_fastq.out.download_status )
-        run_pigz( run_fasterq_dump.out.forward_reads.join( run_fasterq_dump.out.reverse_reads), download_fastq.out.download_status )
+        run_pigz( run_fasterq_dump.out.forward_reads.join( run_fasterq_dump.out.reverse_reads) )
 
         // mix the forward and reverse reads from download_fastq and run_pigz
         forward_reads = download_fastq.out.gzip_forward_reads.mix( run_pigz.out.gzip_forward_reads )
@@ -219,7 +219,7 @@ workflow {
 
         // run only when download_status is emitted from download_fastq
         run_fasterq_dump( download_fastq.out.download_status )
-        run_pigz( run_fasterq_dump.out.forward_reads.join(run_fasterq_dump.out.reverse_reads), download_fastq.out.download_status )
+        run_pigz( run_fasterq_dump.out.forward_reads.join(run_fasterq_dump.out.reverse_reads) )
 
         // mix the forward and reverse reads from download_fastq and run_pigz
         forward_reads = download_fastq.out.gzip_forward_reads.mix( run_pigz.out.gzip_forward_reads )

--- a/main.nf
+++ b/main.nf
@@ -128,12 +128,13 @@ if (params.help) {
 validateParameters()
 
 // Resolve this default after command-line parameters have been applied so that
-// `--outdir custom-results` implies `custom-results/reference_genomes`. An
-// explicit --reference_cache remains independent of --outdir and can therefore
-// be reused by otherwise isolated runs.
-if (!params.reference_cache?.toString()?.trim()) {
-    params.reference_cache = "${params.outdir}/reference_genomes"
-}
+// `--outdir custom-results` implies `custom-results/reference_genomes`. Keep it
+// as an explicit value: mutating params here does not reliably propagate the
+// new value into included modules.
+def resolvedReferenceCache = normalizeParamValue(
+    params.reference_cache,
+    "${params.outdir}/reference_genomes"
+)
 
 // Residual cross-field check that a JSON schema cannot express: the pipeline
 // needs EITHER --input_file OR (--sra_accession AND --identifier). nf-schema
@@ -151,7 +152,7 @@ if ( params.input_file != '' && ( params.sra_accession != '' || params.identifie
 }
 
 log.info("Using container images from ${resolvedContainerRegistry}/${resolvedContainerNamespace}")
-log.info("Using reference genome cache at ${params.reference_cache}")
+log.info("Using reference genome cache at ${resolvedReferenceCache}")
 
 include { get_srrs } from './nf_scripts/get_srrs' addParams(container_image: resolvedContainerImages['sra_parser'])
 include { parse_srrs } from './nf_scripts/parse_srrs' addParams(container_image: resolvedContainerImages['sra_parser'])
@@ -159,7 +160,10 @@ include { download_fastq } from './nf_scripts/download_fastq' addParams(containe
 include { run_fasterq_dump } from './nf_scripts/run_fasterq_dump' addParams(container_image: resolvedContainerImages['sra_tools'])
 include { run_pigz } from './nf_scripts/run_pigz' addParams(container_image: resolvedContainerImages['pigz'])
 include { run_fastp } from './nf_scripts/run_fastp' addParams(container_image: resolvedContainerImages['fastp'])
-include { download_fasta } from './nf_scripts/download_fasta' addParams(container_image: resolvedContainerImages['biopython'])
+include { download_fasta } from './nf_scripts/download_fasta' addParams(
+    container_image: resolvedContainerImages['biopython'],
+    reference_cache: resolvedReferenceCache
+)
 include { run_bowtie2 } from './nf_scripts/run_bowtie2' addParams(container_image: resolvedContainerImages['bowtie2'])
 include { run_samtools } from './nf_scripts/run_samtools' addParams(container_image: resolvedContainerImages['samtools'])
 include { run_bcftools } from './nf_scripts/run_bcftools' addParams(container_image: resolvedContainerImages['bcftools'])

--- a/nf_scripts/download_fastq.nf
+++ b/nf_scripts/download_fastq.nf
@@ -18,18 +18,10 @@ process download_fastq {
     sra_download.sh ${sra_accession}
     """
 
-    // Read-path choice (see PR): emit ONLY the gz reads and DO NOT create
-    // ${sra_accession}.txt. In the real pipeline ${sra_accession}.txt is written
-    // ONLY when the ENA FTP download FAILS; its presence triggers the
-    // fasterq-dump -> pigz fallback (run_fasterq_dump `when: download_status.exists()`).
-    // We reproduce the ENA-SUCCESS branch, giving a SINGLE clean read source
-    // (download_fastq's gz reads; run_fasterq_dump/run_pigz stay dormant). This
-    // avoids feeding duplicate sample keys into main.nf's .mix() (join cardinality
-    // bugs) AND avoids the fasterq-dump fallback, whose sra-tools image lacks
-    // /bin/bash and cannot run under Nextflow's docker wrapper (pre-existing latent
-    // bug; see follow-up note in the PR).
+    // Exercise the fallback route during pipeline stub runs. ENA-success behavior
+    // is covered directly by scripts/test_download_fallback.sh.
     stub:
     """
-    touch ${sra_accession}_1.fastq.gz ${sra_accession}_2.fastq.gz
+    printf 'ENA download unavailable; use SRA Toolkit fallback for %s\n' '${sra_accession}' > ${sra_accession}.txt
     """
 }

--- a/nf_scripts/download_fastq.nf
+++ b/nf_scripts/download_fastq.nf
@@ -2,8 +2,6 @@ process download_fastq {
     label 'process_low'
     maxForks 1
     container "${params.container_image}"
-    errorStrategy 'ignore'
-
     publishDir "${params.outdir}/${sra_accession}/fastq", mode: 'copy'
 
     input:

--- a/nf_scripts/run_fasterq_dump.nf
+++ b/nf_scripts/run_fasterq_dump.nf
@@ -18,7 +18,13 @@ process run_fasterq_dump {
     script:
     """
     prefetch ${download_status.SimpleName}
-    fasterq-dump ${download_status.SimpleName} --threads ${task.cpus} -b 100M -c 200M -m 4G
+    fasterq-dump ${download_status.SimpleName} --split-files --skip-technical --threads ${task.cpus} -b 100M -c 200M -m 4G
+
+    if [ ! -s ${download_status.SimpleName}_1.fastq ] || [ ! -s ${download_status.SimpleName}_2.fastq ]; then
+        rm -f ${download_status.SimpleName}_1.fastq ${download_status.SimpleName}_2.fastq
+        echo 'SRA Toolkit fallback did not produce a complete paired-end read set for ${download_status.SimpleName}; single-end input is not supported.' >&2
+        exit 1
+    fi
     """
 
     stub:

--- a/nf_scripts/run_pigz.nf
+++ b/nf_scripts/run_pigz.nf
@@ -7,14 +7,10 @@ process run_pigz {
 
     input:
     tuple val(sra_accession), path(forward_reads), path(reverse_reads)
-    path download_status
 
     output:
     tuple val(sra_accession), path("${sra_accession}_1.fastq.gz"), emit: gzip_forward_reads
     tuple val(sra_accession), path("${sra_accession}_2.fastq.gz"), emit: gzip_reverse_reads
-
-    when:
-    download_status.exists()
 
     script:
     """

--- a/scripts/test_download_fallback.sh
+++ b/scripts/test_download_fallback.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+export PATH="$repo_root/tests/download_fallback/bin:$PATH"
+
+run_ena_download() {
+    local mode="$1"
+    local run_dir="$2"
+    mkdir -p "$run_dir"
+    (
+        cd "$run_dir"
+        ARIA2_TEST_MODE="$mode" "$repo_root/bin/sra_download.sh" SRR_TEST
+    )
+}
+
+ena_success="$test_root/ena-success"
+run_ena_download success "$ena_success"
+[[ -s "$ena_success/SRR_TEST_1.fastq.gz" ]]
+[[ -s "$ena_success/SRR_TEST_2.fastq.gz" ]]
+[[ ! -e "$ena_success/SRR_TEST.txt" ]]
+
+for incomplete_mode in missing-forward missing-reverse missing-both; do
+    ena_incomplete="$test_root/ena-${incomplete_mode}"
+    run_ena_download "$incomplete_mode" "$ena_incomplete"
+    [[ ! -e "$ena_incomplete/SRR_TEST_1.fastq.gz" ]]
+    [[ ! -e "$ena_incomplete/SRR_TEST_2.fastq.gz" ]]
+    [[ ! -e "$ena_incomplete/SRR_TEST_1.fastq.gz.aria2" ]]
+    [[ ! -e "$ena_incomplete/SRR_TEST_2.fastq.gz.aria2" ]]
+    grep -Fxq 'ENA download unavailable; use SRA Toolkit fallback for SRR_TEST' \
+        "$ena_incomplete/SRR_TEST.txt"
+done
+
+status_dir="$test_root/fallback-status"
+mkdir -p "$status_dir"
+printf 'fallback\n' > "$status_dir/SRR_TEST_A.txt"
+printf 'fallback\n' > "$status_dir/SRR_TEST_B.txt"
+export FALLBACK_TOOL_LOG="$test_root/tool.log"
+export FASTERQ_TEST_MODE=paired
+
+nextflow -C "$repo_root/tests/download_fallback/nextflow.config" \
+    run "$repo_root/tests/download_fallback/main.nf" \
+    --download_status "$status_dir/*.txt" \
+    --outdir "$test_root/fallback-output" \
+    -work-dir "$test_root/fallback-work" \
+    -ansi-log false
+
+for accession in SRR_TEST_A SRR_TEST_B; do
+    [[ -s "$test_root/fallback-output/$accession/fastq/${accession}_1.fastq.gz" ]]
+    [[ -s "$test_root/fallback-output/$accession/fastq/${accession}_2.fastq.gz" ]]
+    grep -Fq "prefetch $accession" "$FALLBACK_TOOL_LOG"
+    grep -Fq "fasterq-dump $accession --split-files --skip-technical" "$FALLBACK_TOOL_LOG"
+    grep -Fq "pigz ${accession}_1.fastq" "$FALLBACK_TOOL_LOG"
+    grep -Fq "pigz ${accession}_2.fastq" "$FALLBACK_TOOL_LOG"
+done
+
+export FASTERQ_TEST_MODE=single-end
+if single_end_output="$(nextflow -C "$repo_root/tests/download_fallback/nextflow.config" \
+    run "$repo_root/tests/download_fallback/main.nf" \
+    --download_status "$status_dir/SRR_TEST_A.txt" \
+    --outdir "$test_root/single-end-output" \
+    -work-dir "$test_root/single-end-work" \
+    -ansi-log false 2>&1)"; then
+    echo "Expected a single-end fallback result to fail." >&2
+    exit 1
+fi
+[[ "$single_end_output" == *"single-end input is not supported"* ]] || {
+    echo "$single_end_output" >&2
+    exit 1
+}
+
+echo "ENA success, incomplete-pair fallback, and multi-accession fasterq-to-pigz routing verified."

--- a/scripts/test_reference_cache.sh
+++ b/scripts/test_reference_cache.sh
@@ -30,13 +30,29 @@ run_pipeline "$test_root/run-b"
     exit 1
 }
 
+default_outdir="$test_root/default-output"
+default_log="$test_root/default-cache.log"
+nextflow run "$repo_root/main.nf" \
+    --input_file "$repo_root/test_data/phage_smoke.csv" \
+    --cpus 1 \
+    --email test@example.com \
+    --outdir "$default_outdir" \
+    -profile docker \
+    -stub-run \
+    -work-dir "$test_root/default-work" \
+    -ansi-log false 2>&1 | tee "$default_log"
+
+grep -Fq "Using reference genome cache at ${default_outdir}/reference_genomes" "$default_log"
+[[ -e "$default_outdir/reference_genomes/NC_000866.4_reference.fasta.gz" ]] || {
+    echo "The implicit reference cache was not created beneath --outdir." >&2
+    exit 1
+}
+
 jq -e '.["$defs"].output_options.properties.reference_cache.type == "string"' \
     "$repo_root/nextflow_schema.json" >/dev/null
-grep -Fq 'reference_cache = "${params.outdir}/reference_genomes"' "$repo_root/main.nf"
-grep -Fq 'storeDir params.reference_cache' "$repo_root/nf_scripts/download_fasta.nf"
 if grep -rn 'results/' "$repo_root/nf_scripts"; then
     echo "Found a hard-coded results/ path in nf_scripts." >&2
     exit 1
 fi
 
-echo "Reference cache reused across distinct output directories."
+echo "Implicit and shared reference cache behavior verified."

--- a/tests/download_fallback/bin/aria2c
+++ b/tests/download_fallback/bin/aria2c
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+target="${url##*/}"
+
+mode="${ARIA2_TEST_MODE:-success}"
+if [[ "$mode" == missing-forward && "$target" == *_1.fastq.gz ]] ||
+   [[ "$mode" == missing-reverse && "$target" == *_2.fastq.gz ]] ||
+   [[ "$mode" == missing-both ]]; then
+    printf 'partial\n' > "$target"
+    touch "${target}.aria2"
+    exit 1
+fi
+
+printf 'complete\n' > "$target"

--- a/tests/download_fallback/bin/fasterq-dump
+++ b/tests/download_fallback/bin/fasterq-dump
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+accession="$1"
+printf 'fasterq-dump %s\n' "$*" >> "${FALLBACK_TOOL_LOG:?}"
+printf '@read/1\nACGT\n+\nIIII\n' > "${accession}_1.fastq"
+if [[ "${FASTERQ_TEST_MODE:-paired}" == paired ]]; then
+    printf '@read/2\nTGCA\n+\nIIII\n' > "${accession}_2.fastq"
+fi

--- a/tests/download_fallback/bin/pigz
+++ b/tests/download_fallback/bin/pigz
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+files=()
+while (($#)); do
+    case "$1" in
+        -f)
+            shift
+            ;;
+        -p)
+            shift 2
+            ;;
+        *)
+            files+=("$1")
+            shift
+            ;;
+    esac
+done
+
+for file in "${files[@]}"; do
+    printf 'pigz %s\n' "$file" >> "${FALLBACK_TOOL_LOG:?}"
+    gzip -c "$file" > "${file}.gz"
+    rm -f "$file"
+done

--- a/tests/download_fallback/bin/prefetch
+++ b/tests/download_fallback/bin/prefetch
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'prefetch %s\n' "$*" >> "${FALLBACK_TOOL_LOG:?}"

--- a/tests/download_fallback/main.nf
+++ b/tests/download_fallback/main.nf
@@ -1,0 +1,11 @@
+nextflow.enable.dsl = 2
+
+include { run_fasterq_dump } from '../../nf_scripts/run_fasterq_dump' addParams(container_image: 'unused-in-local-test')
+include { run_pigz } from '../../nf_scripts/run_pigz' addParams(container_image: 'unused-in-local-test')
+
+workflow {
+    download_status = Channel.fromPath(params.download_status, checkIfExists: true)
+    run_fasterq_dump(download_status)
+    paired_reads = run_fasterq_dump.out.forward_reads.join(run_fasterq_dump.out.reverse_reads)
+    run_pigz(paired_reads)
+}

--- a/tests/download_fallback/nextflow.config
+++ b/tests/download_fallback/nextflow.config
@@ -1,0 +1,7 @@
+process.executor = 'local'
+
+params {
+    download_status = ''
+    outdir = 'results'
+    cpus = 1
+}


### PR DESCRIPTION
## Summary

- pass the resolved implicit reference cache into the download module and prove default/shared cache behavior
- require a complete ENA mate pair, clean partial downloads, and preserve genuine process failures
- make the SRA Toolkit fallback emit paired files, remove the unkeyed status-channel dependency, and exercise two-accession routing under Nextflow
- force Docker stub runs through the fallback containers and document the paired-end-only constraint

Closes #36.

## Local verification

- `make ci` with Nextflow 25.04.8 (passed)
- ShellCheck and `bash -n` for changed/new shell scripts (passed)
- `git diff --check` (passed)
- direct runtime inspection of `quay.io/biocontainers/sra-tools:3.2.1--h4304569_1` confirmed the Nextflow launcher shell and SRA Toolkit executables are present
- separate adversarial review found and prompted removal of the lingering `errorStrategy = ignore` override and expansion to a two-accession fallback regression

## Remaining limits

- single-end runs remain unsupported and now fail explicitly
- ENA outputs are checked for nonempty completion and absence of `.aria2` state, but not with `gzip -t`
- no live-network accession was downloaded end to end; external ENA path conventions and NCBI service behavior remain integration dependencies
- existing `addParams()` use is deprecated but remains functional on the required Nextflow version